### PR TITLE
WiP: SOP-08 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ SPDX-License-Identifier: Apache-2.0
 
 # Changelog
 
+## 8.0.0-SNAPSHOT
+- Rewrote API in Kotlin
+- Update implementation to [SOP Specification revision 08](https://www.ietf.org/archive/id/draft-dkg-openpgp-stateless-cli-08.html).
+  - Add `--no-armor` option to `revoke-key` and `change-key-password` subcommands
+  - `armor`: Deprecate `--label` option
+  - `encrypt`: Add `--session-key-out` option
+- Slight API changes:
+  - `sop.encrypt().plaintext()` now returns a `ReadyWithResult<EncryptionResult>` instead of `Ready`.
+  - `EncryptionResult` is a new result type, that provides access to the session key of an encrypted message
+  - Change `ArmorLabel` values into lowercase
+  - Change `EncryptAs` values into lowercase
+  - Change `SignAs` values into lowercase
+
 ## 7.0.0
 - Update implementation to [SOP Specification revision 07](https://www.ietf.org/archive/id/draft-dkg-openpgp-stateless-cli-07.html).
   - Add support for new `revoke-key` subcommand

--- a/external-sop/src/main/java/sop/external/ExternalSOP.java
+++ b/external-sop/src/main/java/sop/external/ExternalSOP.java
@@ -147,7 +147,7 @@ public class ExternalSOP implements SOP {
 
     @Override
     public Encrypt encrypt() {
-        return new EncryptExternal(binaryName, properties);
+        return new EncryptExternal(binaryName, properties, tempDirProvider);
     }
 
     @Override

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/EncryptCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/EncryptCmdTest.java
@@ -4,28 +4,30 @@
 
 package sop.cli.picocli.commands;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
 import com.ginsberg.junit.exit.ExpectSystemExitWithStatus;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import sop.Ready;
+import sop.EncryptionResult;
+import sop.ReadyWithResult;
 import sop.SOP;
 import sop.cli.picocli.SopCLI;
 import sop.cli.picocli.TestFileUtil;
 import sop.enums.EncryptAs;
 import sop.exception.SOPGPException;
 import sop.operation.Encrypt;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class EncryptCmdTest {
 
@@ -34,10 +36,10 @@ public class EncryptCmdTest {
     @BeforeEach
     public void mockComponents() throws IOException {
         encrypt = mock(Encrypt.class);
-        when(encrypt.plaintext((InputStream) any())).thenReturn(new Ready() {
+        when(encrypt.plaintext((InputStream) any())).thenReturn(new ReadyWithResult<EncryptionResult>() {
             @Override
-            public void writeTo(OutputStream outputStream) {
-
+            public EncryptionResult writeTo(@NotNull OutputStream outputStream) throws IOException, SOPGPException {
+                return new EncryptionResult(null);
             }
         });
 
@@ -190,9 +192,9 @@ public class EncryptCmdTest {
     @Test
     @ExpectSystemExitWithStatus(1)
     public void writeTo_ioExceptionCausesExit1() throws IOException {
-        when(encrypt.plaintext((InputStream) any())).thenReturn(new Ready() {
+        when(encrypt.plaintext((InputStream) any())).thenReturn(new ReadyWithResult<EncryptionResult>() {
             @Override
-            public void writeTo(OutputStream outputStream) throws IOException {
+            public EncryptionResult writeTo(@NotNull OutputStream outputStream) throws IOException, SOPGPException {
                 throw new IOException();
             }
         });

--- a/sop-java/src/main/kotlin/sop/EncryptionResult.kt
+++ b/sop-java/src/main/kotlin/sop/EncryptionResult.kt
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2023 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sop
+
+import sop.util.Optional
+
+class EncryptionResult(sessionKey: SessionKey?) {
+    val sessionKey: Optional<SessionKey>
+
+    init {
+        this.sessionKey = Optional.ofNullable(sessionKey)
+    }
+}

--- a/sop-java/src/main/kotlin/sop/operation/Encrypt.kt
+++ b/sop-java/src/main/kotlin/sop/operation/Encrypt.kt
@@ -6,8 +6,9 @@ package sop.operation
 
 import java.io.IOException
 import java.io.InputStream
+import sop.EncryptionResult
 import sop.Profile
-import sop.Ready
+import sop.ReadyWithResult
 import sop.enums.EncryptAs
 import sop.exception.SOPGPException.*
 import sop.util.UTF8Util
@@ -146,20 +147,22 @@ interface Encrypt {
      * Encrypt the given data yielding the ciphertext.
      *
      * @param plaintext plaintext
-     * @return input stream containing the ciphertext
+     * @return result and ciphertext
      * @throws IOException in case of an IO error
      * @throws KeyIsProtected if at least one signing key cannot be unlocked
      */
-    @Throws(IOException::class, KeyIsProtected::class) fun plaintext(plaintext: InputStream): Ready
+    @Throws(IOException::class, KeyIsProtected::class)
+    fun plaintext(plaintext: InputStream): ReadyWithResult<EncryptionResult>
 
     /**
      * Encrypt the given data yielding the ciphertext.
      *
      * @param plaintext plaintext
-     * @return input stream containing the ciphertext
+     * @return result and ciphertext
      * @throws IOException in case of an IO error
      * @throws KeyIsProtected if at least one signing key cannot be unlocked
      */
     @Throws(IOException::class, KeyIsProtected::class)
-    fun plaintext(plaintext: ByteArray): Ready = plaintext(plaintext.inputStream())
+    fun plaintext(plaintext: ByteArray): ReadyWithResult<EncryptionResult> =
+        plaintext(plaintext.inputStream())
 }


### PR DESCRIPTION
The spec lists the following changes between 07 and 08:
* [x] revoke-key, change-key-password: add --no-armor option
  Implemented. Needs testing maybe.
* [x] generate-key: should fail on non-UTF-8 USERID
  We cannot really do much here, since we are limited to UTF8 strings as input anyways.
* [x] generate-key: acknowledge that implementations MAY reject USERIDs that seem bad
  See above, not really an issue for us, but we should write a test.
* [x] armor: drop --label option
  I decided to deprecate the label option, but leave it in the CLI for now.
* [x] encrypt: add --session-key-out option
  Implemented, but needs testing.
* [ ] ASCII-armored objects should not be concatenated
  We don't accept these anyways. Could use testing though.
* [ ] signature verification should only work for sigtypes 0x00 (binary) and 0x01 (canonical text)
  This is how we implemented signature verification anyways. Could use tests though.
* [ ] sign: Constrain input when --micalg-out is present for alignment with [[RFC3156](https://www.ietf.org/archive/id/draft-dkg-openpgp-stateless-cli-08.html#RFC3156)]
* [x] propose simple C API for signing and verification
  Nothing to do for us here.